### PR TITLE
add quickcheck.ml generators for int32 and int64

### DIFF
--- a/qtest/quickcheck.ml
+++ b/qtest/quickcheck.ml
@@ -50,6 +50,19 @@ let upos =
 
 let uig () = if Random.bool () then - upos () - 1 else upos ()
 
+let random_binary_string length =
+  (* 0b011101... *)
+  let s = String.create (length + 2) in
+  s.[0] <- '0';
+  s.[1] <- 'b';
+  for i = 0 to length - 1 do
+    s.[i+2] <- if Random.bool () then '0' else '1'
+  done;
+  s
+
+let ui32g () = Int32.of_string (random_binary_string 32)  
+let ui64g () = Int64.of_string (random_binary_string 64)
+
 let lg_size size gen () =
   foldn ~f:(fun acc _ -> (gen ())::acc) ~init:[] (size ())
 let lg gen () = lg_size nng gen ()
@@ -109,6 +122,9 @@ let int = (uig, string_of_int)
 let pos_int = (upos, string_of_int)
 let small_int = (nng, string_of_int)
 let neg_int = (neg_ig, string_of_int)
+  
+let int32 = (ui32g, fun i -> Int32.to_string i ^ "l")
+let int64 = (ui64g, fun i -> Int64.to_string i ^ "L")
 
 let char = (cg, sprintf "%C")
 let printable_char = (printable, sprintf "%C")

--- a/qtest/quickcheck.mli
+++ b/qtest/quickcheck.mli
@@ -28,6 +28,12 @@ val neg_float : float gen_print
 val int : int gen_print
 (** int generator. Uniformly distributed *)
 
+val int32 : int32 gen_print
+(** int32 generator. Uniformly distributed *)
+
+val int64 : int64 gen_print
+(** int generator. Uniformly distributed *)
+
 val pos_int : int gen_print
 (** positive int generator. Uniformly distributed *)
 


### PR DESCRIPTION
The implementation is very stupid (it would be possible to be more efficient through clever use of `Random.bits`), but also very simple, and it's better than to have none at all.
